### PR TITLE
Make sure to keep matrices

### DIFF
--- a/R/quadprog.solve.QP.R
+++ b/R/quadprog.solve.QP.R
@@ -21,9 +21,9 @@ quadprog.solve.QP <- function(Dmat, dvec, Amat, bvec, meq=0, factorized=FALSE) {
   # extract equalities and inequalities
   if (meq > 0) {
     eq_ind = 1:meq
-    CE = Amat[, eq_ind]
+    CE = Amat[, eq_ind, drop = FALSE]
     ce0 = bvec[eq_ind]
-    CI = Amat[, -eq_ind]
+    CI = Amat[, -eq_ind, drop = FALSE]
     ci0 = bvec[-eq_ind]
   } else {
     CE = matrix(0, n, 0)


### PR DESCRIPTION
PR to solve `Error: Not a matrix.` when I run this:
```r
args <- list(Dmat = structure(c(281185.204002431, -92893.8557890011, -60253.5974698126, 
                                -92893.8557890011, 76702.9901253211, -29939.5787486647, 
                                -60253.5974698126, -29939.5787486647, 66906.8909868694), dim = c(3L,  3L)), 
             dvec = c(-3904.83151316259, -37825.1061016761, 43208.6624650392),
             Amat = structure(c(-1, -1, -1, 1, 0, 0, 0, 1, 0, 0, 0, 1), dim = 3:4), 
             bvec = c(-1, 0, 0, 0), meq = 1)
do.call(quadprogpp::quadprog.solve.QP, args)
```